### PR TITLE
modify make-dotted-list and fix package

### DIFF
--- a/octo.asd
+++ b/octo.asd
@@ -20,7 +20,10 @@
   :components ((:module "src"
                 :components
                         ((:file "package")
-                         (:file "threading" :depends-on ("package"))
+			 (:file "octo")
+			 (:file "list")
+			 (:file "threading")
+			 (:file "svg")
                          )))
   :description "Utility collection."
   :long-description

--- a/src/octo.lisp
+++ b/src/octo.lisp
@@ -1,16 +1,3 @@
-(in-package :cl-user)
-(defpackage octo
-  (:use :cl)
-  (:export
-   :let1
-   :last1
-   :singlep
-   :append1
-   :conc1
-   :mklist 
-   :alist->plist
-   :plist->alist
-   :with))
 (in-package :octo)
 
 (defmacro let1 (var val &body body)
@@ -41,8 +28,7 @@
 ;;; TODO: もっと読みやすい書き方があるはず。 
 (defun make-dotted-list (list)
   "Convert a two-element list into a dotted list."
-  (cond ((null list) nil)
-        ((not (consp list)) nil)
+  (cond ((not (consp list)) list)
         ((singlep list) (first list))
         (t (cons (first list)
                  (make-dotted-list (rest list))))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,4 +1,26 @@
 (defpackage :octo
   (:use :cl :alexandria)
+  ;; threading.lisp
   (:export #:->
-           #:->>))
+           #:->>)
+  ;; octo.lisp
+  (:export #:let1
+	   #:last1
+	   #:singlep
+	   #:append1
+	   #:conc1
+	   #:mklist 
+	   #:alist->plist
+	   #:make-dotted-list
+	   #:plist->alist
+	   #:plist->bindings
+	   #:with)
+  ;; list.lisp
+  (:export #:map-when
+	   #:map-first
+	   #:map-last
+	   #:map-indexed
+	   #:annotate
+	   #:splice
+	   #:splice-list
+	   #:mapcat))


### PR DESCRIPTION
I modify make-dotted-list.
e.g .
```
> (make-dotted-list '(foo . bar))
=> (foo . bar)
```
Also, fix package to export functions.